### PR TITLE
Refactor patti parser

### DIFF
--- a/src/conf/from_jsonconf.rs
+++ b/src/conf/from_jsonconf.rs
@@ -460,7 +460,7 @@ mod tests {
                     ),
                 ]
             },
-            res_header.0
+            res_header
         );
 
         assert_eq!(
@@ -487,7 +487,7 @@ mod tests {
                     ),
                 ]
             },
-            res_line01.0
+            res_line01
         );
     }
 }

--- a/src/conf/from_jsonconf.rs
+++ b/src/conf/from_jsonconf.rs
@@ -211,7 +211,8 @@ pub fn patti_csv_file_parser_from<'rd>(
     builder
         .enclosure_char(cfg.parser_opts.enclosure_char)
         .separator_char(cfg.parser_opts.separator_char)
-        .first_line_is_header(cfg.parser_opts.first_line_is_header);
+        .first_line_is_header(cfg.parser_opts.first_line_is_header)
+        .save_skipped_lines(cfg.parser_opts.save_skipped_lines);
 
     if let Some(mut san) = cfg.sanitize_columns {
         let mut transitizers: HashMap<Option<usize>, TransformSanitizeTokens> = HashMap::new();
@@ -359,13 +360,14 @@ mod tests {
                 enclosure_char: Some('"'),
                 lines: Some(ParserOptLines {
                     comment: None,
-                    skip_lines_from_start: Some(1 as usize),
+                    skip_lines_from_start: Some(1_usize),
                     skip_empty_lines: Some(true),
                     skip_lines_by_startswith: Some(vec![String::from("#"), String::from("-")]),
                     take_lines_by_startswith: None,
                     skip_lines_from_end: None,
                 }),
                 first_line_is_header: true,
+                save_skipped_lines: false,
             },
             sanitize_columns: Some(vec![
                 SanitizeColumnsEntry {

--- a/src/conf/from_jsonconf.rs
+++ b/src/conf/from_jsonconf.rs
@@ -94,29 +94,31 @@ impl TryFrom<&mut SanitizeColumnsEntry> for (Option<usize>, TransformSanitizeTok
 
 impl From<&mut TypeColumnsEntry> for TypeColumnEntry {
     fn from(tce: &mut TypeColumnsEntry) -> Self {
-        let src_pattern = tce.src_pattern.as_mut();
-        let map_to_none = tce.map_to_none.as_mut();
-        match (&src_pattern, &map_to_none) {
+        let src_pattern_opt = tce.src_pattern.as_mut();
+        let map_to_none_opt = tce.map_to_none.as_mut();
+        match (src_pattern_opt, map_to_none_opt) {
             (None, None) => TypeColumnEntry::new(
                 std::mem::take(&mut tce.header),
                 std::mem::take(&mut tce.target_type),
             ),
-            (None, Some(_)) => TypeColumnEntry::new_with_map_to_none(
+            (None, Some(map_to_none)) => TypeColumnEntry::new_with_map_to_none(
                 std::mem::take(&mut tce.header),
                 std::mem::take(&mut tce.target_type),
-                std::mem::take(map_to_none.unwrap()), // checked in match
+                std::mem::take(map_to_none),
             ),
-            (Some(_), None) => TypeColumnEntry::new_with_chrono_pattern(
+            (Some(src_pattern), None) => TypeColumnEntry::new_with_chrono_pattern(
                 std::mem::take(&mut tce.header),
                 std::mem::take(&mut tce.target_type),
-                std::mem::take(src_pattern.unwrap()), // checked in match
+                std::mem::take(src_pattern),
             ),
-            (Some(_), Some(_)) => TypeColumnEntry::new_with_chrono_pattern_with_map_to_none(
-                std::mem::take(&mut tce.header),
-                std::mem::take(&mut tce.target_type),
-                std::mem::take(src_pattern.unwrap()), // checked in match
-                std::mem::take(map_to_none.unwrap()), // checked in match
-            ),
+            (Some(src_pattern), Some(map_to_none)) => {
+                TypeColumnEntry::new_with_chrono_pattern_with_map_to_none(
+                    std::mem::take(&mut tce.header),
+                    std::mem::take(&mut tce.target_type),
+                    std::mem::take(src_pattern),
+                    std::mem::take(map_to_none),
+                )
+            }
         }
     }
 }
@@ -286,7 +288,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_from_sanitize_column_entry_for_idx_and_trans_san_token_tuple_trim_all() {
+    fn from_sanitize_column_entry_for_idx_and_trans_san_token_tuple_trim_all() {
         let mut sce = SanitizeColumnsEntry {
             comment: None,
             idx: None,
@@ -305,7 +307,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_sanitize_column_entry_for_idx_and_trans_san_token_tuple_replace_with() {
+    fn from_sanitize_column_entry_for_idx_and_trans_san_token_tuple_replace_with() {
         let mut sce = SanitizeColumnsEntry {
             comment: None,
             idx: Some(1),
@@ -331,7 +333,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_type_columns_entry_for_type_column_entry_no_date_type() {
+    fn from_type_columns_entry_for_type_column_entry_no_date_type() {
         let exp = TypeColumnEntry::new(Some(String::from("header-1")), ValueType::Char);
         let mut test = TypeColumnsEntry::builder()
             .with_header("header-1")
@@ -341,7 +343,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_type_columns_entry_for_type_column_entry_date_type() {
+    fn from_type_columns_entry_for_type_column_entry_date_type() {
         let exp = TypeColumnEntry::new(Some(String::from("header-1")), ValueType::DateTime);
         let mut test = TypeColumnsEntry::builder()
             .with_header("header-1")
@@ -351,7 +353,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_from_data_cfg_root_tuple_for_patti_csv_parser_1() {
+    fn try_from_data_cfg_root_tuple_for_patti_csv_parser_1() {
         let cfg = ConfigRoot {
             comment: None,
             parser_opts: ParserOpts {

--- a/src/conf/jsonconf.rs
+++ b/src/conf/jsonconf.rs
@@ -31,6 +31,7 @@ pub struct ParserOpts {
     pub enclosure_char: Option<char>,
     pub lines: Option<ParserOptLines>,
     pub first_line_is_header: bool,
+    pub save_skipped_lines: bool,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -181,7 +182,7 @@ mod tests {
                 skip_lines_from_end: Some(1),
                 skip_lines_by_startswith: Some(vec!["foo".to_string(), "-".to_string()]),
                 take_lines_by_startswith: Some(vec!["bar".to_string()]),
-                skip_empty_lines: Some(true)
+                skip_empty_lines: Some(true),
             },
             serde_json::from_str(data).expect("could not deserialize ")
         )
@@ -389,6 +390,7 @@ mod tests {
                     "skipLinesByStartswith": ["#", "-"],
                     "skipEmptyLines": true
                 },
+                "saveSkippedLines": false,
                 "firstLineIsHeader": true
             },
             "sanitizeColumns": [{
@@ -436,6 +438,7 @@ mod tests {
                     take_lines_by_startswith: None,
                 }),
                 first_line_is_header: true,
+                save_skipped_lines: false,
             },
             sanitize_columns: Some(vec![
                 SanitizeColumnsEntry {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,6 +11,7 @@ pub enum WrappedErrors {
 #[derive(Debug, PartialEq, Display, Clone)]
 pub enum PattiCsvError {
     Generic { msg: String },
+    ConfigError { msg: String },
     Wrapped(WrappedErrors),
     Tokenize(TokenizerError),
     Sanitize(SanitizeError),

--- a/src/iterating_parser.rs
+++ b/src/iterating_parser.rs
@@ -159,6 +159,9 @@ impl<'rd, R: Read> PattiCsvParserIterator<'rd, R> {
             None => None,
         }
     }
+    pub fn save_skipped_lines(&self) -> bool {
+        self.pcp.dlt_iter.save_skipped_lines()
+    }
     pub fn first_line_is_header(&self) -> bool {
         self.pcp.first_line_is_header()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod conf;
 pub mod errors;
 pub mod iterating_parser;
 pub mod line_tokenizer; // works, tested
@@ -5,4 +6,3 @@ pub mod parser_common; // works, tested
 pub mod parser_config; // no tests, just struct definitions
 pub mod skip_take_lines; // works, tested
 pub mod transform_sanitize_token; // works, tested
-pub mod conf;

--- a/src/line_tokenizer.rs
+++ b/src/line_tokenizer.rs
@@ -130,7 +130,7 @@ impl<'rd, R: Read> DelimitedLineTokenizer<'rd, R> {
                 .map(|filter| {
                     (
                         filter.skip(Some(line_counter), Some(line)),
-                        Some(filter.get_self_info()),
+                        Some(filter.get_self_info()), // TODO: bad for performance?
                     )
                 }) // check line against every sanitizer
                 .find(|(res, _info)| *res) // if at least one yields true, we need to skip (this line)
@@ -245,6 +245,9 @@ pub struct DelimitedLineTokenizerIter<'rd, R: Read> {
 }
 
 impl<'rd, R: Read> DelimitedLineTokenizerIter<'rd, R> {
+    pub fn save_skipped_lines(&self) -> bool {
+        *(&self.dlt.save_skipped_lines)
+    }
     pub fn get_skipped_lines(&self) -> &Option<HashMap<usize, SkippedLineInfo>> {
         &self.skipped_lines
     }

--- a/src/skip_take_lines.rs
+++ b/src/skip_take_lines.rs
@@ -1,5 +1,6 @@
 pub trait SkipTakeLines {
     fn skip(&self, line_num: Option<usize>, line_content: Option<&str>) -> bool;
+    fn get_self_info(&self) -> String;
 }
 
 #[derive(Debug)]
@@ -12,6 +13,9 @@ impl SkipTakeLines for SkipLinesFromStart {
             Some(ln) => ln <= self.skip_num_lines,
             None => false,
         }
+    }
+    fn get_self_info(&self) -> String {
+        format!("{self:?}")
     }
 }
 
@@ -27,6 +31,9 @@ impl SkipTakeLines for SkipLinesFromEnd {
             None => false,
         }
     }
+    fn get_self_info(&self) -> String {
+        format!("{self:?}")
+    }
 }
 
 #[derive(Debug)]
@@ -39,6 +46,9 @@ impl SkipTakeLines for SkipLinesStartingWith {
             Some(c) => c.starts_with(&self.starts_with),
             None => false,
         }
+    }
+    fn get_self_info(&self) -> String {
+        format!("{self:?}")
     }
 }
 
@@ -53,6 +63,9 @@ impl SkipTakeLines for TakeLinesStartingWith {
             None => false,
         }
     }
+    fn get_self_info(&self) -> String {
+        format!("{self:?}")
+    }
 }
 
 #[derive(Debug)]
@@ -63,6 +76,9 @@ impl SkipTakeLines for SkipEmptyLines {
             Some(c) => c.eq("\n") || c.eq("\r\n"), // nothing there besides newline
             None => false,
         }
+    }
+    fn get_self_info(&self) -> String {
+        format!("{self:?}")
     }
 }
 


### PR DESCRIPTION
refactoring to use compact_string in the tokenizer for a small speed improvement.
overall code quality improvement and comments added